### PR TITLE
Support for custom Xcode app path

### DIFF
--- a/Sources/HotReloading/InjectionClient.swift
+++ b/Sources/HotReloading/InjectionClient.swift
@@ -168,6 +168,12 @@ public class InjectionClient: SimpleSocket, InjectionReader {
             builder.derivedLogs = nil;
         case .watching:
             log("Watching files under the directory \(readString() ?? "Missing directory")")
+        case .xcodeAppPath:
+            let xcodeAppPath = readString()
+            log("Xcode app path set at \(xcodeAppPath ?? "Missing path")")
+            if let xcodeAppPath = xcodeAppPath {
+                builder.xcodeAppPath = xcodeAppPath
+            }
         case .log:
             log(readString() ?? "Missing log message")
         case .ideProcPath:

--- a/Sources/HotReloading/SwiftEval.swift
+++ b/Sources/HotReloading/SwiftEval.swift
@@ -183,6 +183,11 @@ public class SwiftEval: NSObject {
     }
 
     // Xcode related info
+    @objc public var xcodeAppPath: String = "/Applications/Xcode.app" {
+        didSet {
+            xcodeDev = xcodeAppPath + "/Contents/Developer"
+        }
+    }
     @objc public var xcodeDev = "/Applications/Xcode.app/Contents/Developer"
 
     @objc public var projectFile: String?

--- a/Sources/HotReloadingGuts/include/InjectionClient.h
+++ b/Sources/HotReloadingGuts/include/InjectionClient.h
@@ -68,6 +68,7 @@ typedef NS_ENUM(int, InjectionCommand) {
     // commands to Bundle
     InjectionConnected,
     InjectionWatching,
+    InjectionXcodeAppPath,
     InjectionLog,
     InjectionSigned,
     InjectionLoad,

--- a/Sources/HotReloadingGuts/include/UserDefaults.h
+++ b/Sources/HotReloadingGuts/include/UserDefaults.h
@@ -21,3 +21,4 @@ static NSString *const UserDefaultsLookup = @"typeLookup";
 static NSString *const UserDefaultsRemote = @"appRemote";
 static NSString *const UserDefaultsReplay = @"replayInjections";
 static NSString *const UserDefaultsUnlock = @"deviceUnlock";
+static NSString *const UserDefaultsXcodeAppPath = @"xcodeAppPath";

--- a/Sources/injectiond/InjectionServer.swift
+++ b/Sources/injectiond/InjectionServer.swift
@@ -122,18 +122,22 @@ public class InjectionServer: SimpleSocket {
                 self.log("Signing with identity: \(identity!)")
             }
             return SignerService.codesignDylib(
-                self.builder.tmpDir+"/eval"+$0, identity: identity)
+                self.builder.tmpDir+"/eval"+$0,
+                identity: identity,
+                xcodePath: appDelegate.xcodeAppPath
+            )
         }
 
         // Xcode specific config
-        if let xcodeDevURL = appDelegate.runningXcodeDevURL {
-            builder.xcodeDev = xcodeDevURL.path
+        if let xcodeAppURL = appDelegate.runningXcodeAppURL {
+            builder.xcodeAppPath = xcodeAppURL.path
         }
 
         builder.projectFile = projectFile
 
         appDelegate.setMenuIcon(.ok)
         appDelegate.lastConnection = self
+        setXcodeAppPath(appDelegate.xcodeAppPath)
         pending = []
 
         var lastInjected = projectInjected[projectFile]
@@ -343,6 +347,10 @@ public class InjectionServer: SimpleSocket {
         fileWatchers.append(FileWatcher(root: directory,
                                         callback: fileChangeHandler))
         sendCommand(.watching, with: directory)
+    }
+
+    public func setXcodeAppPath(_ path: String) {
+        sendCommand(.xcodeAppPath, with: path)
     }
 
     @objc public func injectPending() {

--- a/Sources/injectiondGuts/include/SignerService.h
+++ b/Sources/injectiondGuts/include/SignerService.h
@@ -10,6 +10,6 @@
 
 @interface SignerService: NSObject
 
-+ (BOOL)codesignDylib:(NSString * _Nonnull)dylib identity:(NSString * _Nullable)identity;
++ (BOOL)codesignDylib:(NSString * _Nonnull)dylib identity:(NSString * _Nullable)identity xcodePath:(NSString * _Nullable)xcodePath;
 
 @end


### PR DESCRIPTION
**Problem**
Sometimes developers has several installed xcode version on their local machines: `Xcode_13.4.1.app`, `Xcode_13.2.1.app` etc.

**Previous solution**
As a workaround developers can create symlink as described [here](https://github.com/johnno1962/InjectionIII/issues/403#issuecomment-1156464874).
But unfortunately this solution doesn't work well in case the developer has more than one version of Xcode with main one installed as `Xcode.app`

**Solution**
In this PR is implemented the ability to give the developer an option to select a path to desired installed Xcode version