### PR TITLE
Fix “Invalid platform MacOSX” warning

### DIFF
--- a/Sources/HotReloading/SwiftEval.swift
+++ b/Sources/HotReloading/SwiftEval.swift
@@ -536,7 +536,7 @@ public class SwiftEval: NSObject {
             osSpecific = "-mtvos-simulator-version-min=9.0"
         case "AppleTVOS":
             osSpecific = "-mtvos-version-min=9.0"
-        case "MacOS":
+        case "MacOSX":
             let target = compileCommand
                 .replacingOccurrences(of: #"^.*( -target \S+).*$"#,
                                       with: "$1", options: .regularExpression)


### PR DESCRIPTION
While debugging an unrelated issue getting HotReloading working in a Mac app, I noticed the following warning:

> 🔥 ⚠️ Invalid platform MacOSX

It looks like this was introduced [here](https://github.com/johnno1962/HotReloading/commit/bd21cedbcfb2471ac4acb5c8bd7f83224f6bb4d1#diff-64e6f95fd78315276f64814ae968e1e38deb5d4f89f259b3bcddd165e2e59828L514-L516) as part of #56.

This "bug" doesn't seem to actually break code reloading. The only effect of fixing it is adding the following linker arguments: `-mmacosx-version-min=10.11  -target arm64-apple-macos12.3`, and I'm not familiar enough with the internals of HotReloading to know how much that matters. But I'm pretty sure this is an improvement regardless.