### PR TITLE
fix: -o option not found for bazel

### DIFF
--- a/Sources/HotReloading/SwiftEval.swift
+++ b/Sources/HotReloading/SwiftEval.swift
@@ -497,10 +497,13 @@ public class SwiftEval: NSObject {
         }
 
         debug("Final command:", compileCommand, "-->", objectFile)
-        guard shell(command: """
-                (cd "\(projectRoot.escaping("$"))" && \
-                \(compileCommand) -o "\(objectFile)" >\"\(logfile)\" 2>&1)
-                """) || isBazelCompile else {
+        var cmd = "(cd \(projectRoot.escaping("$")) && \(compileCommand) ";
+        if isBazelCompile {
+            cmd += "> \"\(logfile)\" 2>&1)";
+        } else {
+            cmd += "-o \"\(objectFile)\" > \"\(logfile)\" 2>&1)";
+        }
+        guard shell(command: cmd) || isBazelCompile else {
             compileByClass.removeValue(forKey: classNameOrFile)
             longTermCache.removeObject(forKey: classNameOrFile)
             longTermCache.write(toFile: buildCacheFile,


### PR DESCRIPTION
I've found that the latest `4.6.4` cannot compile source files to obj files due to `-o option not found` for bazel. This PR divides them and add `-o` dynamically.