### PR TITLE
Support for different custom build configurations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,13 +44,17 @@ let package = Package(
 //                 .upToNextMinor(from: "1.2.12")),
     ],
     targets: [
-        .target(name: "HotReloading", dependencies: ["HotReloadingGuts",
-             "SwiftTrace", .product(name: "Xprobe", package: "XprobePlugin"),
-                 .product(name: "SwiftRegex", package: "SwiftRegex")/*, "DLKit",
-                 "InjectionScratch"*/]/*, linkerSettings: [.unsafeFlags([
+        .target(name: "HotReloading",
+                dependencies: ["HotReloadingGuts",
+                               "SwiftTrace",
+                               .product(name: "Xprobe", package: "XprobePlugin"),
+                               .product(name: "SwiftRegex", package: "SwiftRegex")
+                               /*, "DLKit", InjectionScratch"*/],
+                swiftSettings: [.define("DEBUG")]
+                /*, linkerSettings: [.unsafeFlags([
                     "-Xlinker", "-interposable", "-undefined", "dynamic_lookup"])]*/),
         .target(name: "HotReloadingGuts",
-                cSettings: [.define("DEVELOPER_HOST", to: "\"\(hostname)\"")]),
+                cSettings: [.define("DEVELOPER_HOST", to: "\"\(hostname)\""), .define("DEBUG")]),
         .target(name: "injectiondGuts"),
         .target(name: "injectiond", dependencies: ["HotReloadingGuts", "injectiondGuts",
                                    .product(name: "SwiftRegex", package: "SwiftRegex"),


### PR DESCRIPTION
## Description

I reported an issue last week, and it turns out that SPM is missing builds when the "Custom Build Configuration" (such as Test) only exists in the main app.

There have been a lot of reports about this.

1. [how-to-use-a-custom-build-configuration-in-a-swift-package](https://forums.swift.org/t/how-to-use-a-custom-build-configuration-in-a-swift-package/36259/18)
2. [spm-in-xcode](https://www.sobyte.net/post/2022-10/spm-in-xcode/)

As SPM does not support custom build configurations, only the configurations that contain "debug" in their names make the Xcode builder put the DEBUG flag in the build options. 

I reported it through Feedback Assistant (FB12343218) and now waiting for its response.

HotReloading module should be removed from the release build anyway, 
What about putting DEBUG flag in the overall flags?
Could you please check these changes?

Fixes #82 [issue](https://github.com/johnno1962/HotReloading/issues/82)

## Type of change

Please delete options that are not relevant.

- [V ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Using [SwiftUI-Kit](https://github.com/johnno1962/SwiftUI-Kit),
I tested it with multiple schemes and multiple build configurations, and everything worked fine.
I checked on the Device and it was fine.


